### PR TITLE
build: ci versioning whenever merge on main

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,17 @@
+name: Bump version in git
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bump version
+        run: |
+          git config --global user.email "github+actions@gmail.com"
+          git config --global user.name "Actions"
+          git fetch --tags
+          curl -s https://raw.githubusercontent.com/treeder/bump/master/gitbump.sh | bash -s


### PR DESCRIPTION
This uses a container (https://github.com/treeder/bump) to bump the version based on latest git tag.